### PR TITLE
Update rfy-afa-ai-tabs.css

### DIFF
--- a/desktop/rfy-afa-ai-tabs.css
+++ b/desktop/rfy-afa-ai-tabs.css
@@ -9,7 +9,7 @@
 #vvp-items-button--recommended a::before,
 #vvp-items-button--all a::before,
 #vvp-items-button--seller a::before {
-    color: black !important;
+    color: initial;
     position: absolute !important;
     font-size: 20px !important;
     font-weight: bold !important;


### PR DESCRIPTION
Changing the color of the text to `initial` without the `!important` flag works with the default CSS as well as my dark mode (which I just updated). If it was left in, it would have overridden any other custom styling changes from my dark mode styling.