### PR TITLE
Use vars for grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ if you want to use the dark theme, also include:
 Those are the public styles that we created, if you don't want all of them you can remove the line that represents the functionality that you do not want.
 For example ```@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/pagination-on-top.css);``` makes the pagination to be on the top of the page, just don't include this line if you dont want that.
 
+### variable-defs.css:
+- Use if you want to define your own tile size for the product grid
+- Place your override definitions above the small-items.css and more-description-text.css files
+  
 ### small-items.css:
 - Show more items per row in the page
+
 ### remove-header.css:
 - Removes the website header
 ### remove-footer.css:
@@ -62,26 +67,40 @@ For example ```@import url(https://raw.githubusercontent.com/Thorvarium/vine-sty
 - Enables dark theme on all vine pages
 
 ## Customization
-if you want to customize some specific style you can also open the files that you want to customize, copy the part that you want changed and include at the bottom of the stylebot file. This way you can tweak the numbers that you want customized.
+If you want to customize just the product grid, you can place a block that will override the sizing at the very top. The stylesheet will automatically adjust a few other proportions if you define only ``--cust-item-tile-size``. 
+
+You must have variable-defs.css included immediately below your definition. Other variables you can use are listed in the file variable-defs.css.
+
+if you want to customize some other specific style you can also open the files that you want to customize, copy the part that you want changed and include at the *bottom* of the stylebot file. This way you can tweak the numbers that you want customized.
 
 Example:
 
 ```
+:root{
+  --cust-item-tile-height:50px;
+}
+
+@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/variable-defs.css)
 @import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/small-items.css);
 /* ... all other imports ... */
 @import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/collapsable-categories.css);
 
-#vvp-items-grid {
-  grid-template-columns: repeat(auto-fill,minmax(75px,auto)) !important;
+.a-button-primary {
+    background: plum !important;
+    border-color: plum !important;
+}
+.a-button-primary:hover .a-button-text {
+    color: white !important;
+}
+.a-button-primary:hover {
+    background: purple !important;
+    border-color: violet !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
-  width: 75px !important;
-}
 ```
-This will make the items even smaller
+This makes the items smaller by setting ``--cust-item-tile-size`` at the top.
 
-
+The css at the bottom changes the See Details button color to use plum, purple, and violet.
 
 # Android
 For Android, we recommend a browser called "Kiwi Browser", this browser supports extensions. 
@@ -143,11 +162,14 @@ for iOS and iPadOS:
 - change the "then" condition to "inject Css from URL"
 - use the url: ```https://raw.githubusercontent.com/Thorvarium/vine-styling/main/mobile/mobile.css```
 
+
 ## Additional customizations
 Both are limited to custom css hosted from a url, and not css definitions saved in the stylesheets.
 
 However, you can write and host your own overrides to the styles defined in the vine-styling project. You create a .css file. You make the css changes you wish to see. 
 Then add an additional Action for your configuration, specifying the URL to your CSS file.
+
+To adjust tile sizes, if you are using mobile.css, the variable-defs.css file is not necessary. You will still need to create and host a css file that contains the redefined values.
 
 Your hosting choices are up to you, but options include
 - dropbox

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For example ```@import url(https://raw.githubusercontent.com/Thorvarium/vine-sty
 - Enables dark theme on all vine pages
 
 ## Customization
-If you want to customize just the product grid, you can place a block that will override the sizing at the very top. The stylesheet will automatically adjust a few other proportions if you define only ``--cust-item-tile-size``. 
+If you want to customize just the product grid, you can place a block that will override the sizing at the very top. The stylesheet will automatically adjust a few other proportions if you define only ``--custom-item-tile-size``. 
 
 You must have variable-defs.css included immediately below your definition. Other variables you can use are listed in the file variable-defs.css.
 
@@ -77,7 +77,7 @@ Example:
 
 ```
 :root{
-  --cust-item-tile-height:50px;
+  --custom-item-tile-height:50px;
 }
 
 @import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/variable-defs.css)
@@ -98,7 +98,7 @@ Example:
 }
 
 ```
-This makes the items smaller by setting ``--cust-item-tile-size`` at the top.
+This makes the items smaller by setting ``--custom-item-tile-size`` at the top.
 
 The css at the bottom changes the See Details button color to use plum, purple, and violet.
 

--- a/desktop/more-description-text.css
+++ b/desktop/more-description-text.css
@@ -2,7 +2,7 @@
   .vvp-item-tile
   .vvp-item-tile-content
   > .vvp-item-product-title-container {
-  height: var(--item-title-height, 40px) !important;
+  height: var(--item-tile-height, 40px) !important;
   font-size: var(--product-title-text-size, 10px) !important;
 }
 
@@ -11,5 +11,5 @@
   .vvp-item-tile-content
   > .vvp-item-product-title-container
   .a-truncate {
-  max-height: var(--item-title-height, 40px) !important;
+  max-height: var(--item-tile-height, 40px) !important;
 }

--- a/desktop/more-description-text.css
+++ b/desktop/more-description-text.css
@@ -1,8 +1,15 @@
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container {
-  height: 40px !important;
-  font-size: 10px !important;
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container {
+  height: var(--item-title-height, 40px) !important;
+  font-size: var(--product-title-text-size, 10px) !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container .a-truncate {
-  max-height: 40px !important;
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container
+  .a-truncate {
+  max-height: var(--item-title-height, 40px) !important;
 }

--- a/desktop/small-items.css
+++ b/desktop/small-items.css
@@ -1,113 +1,124 @@
-    #vvp-header {
-      margin: 0px;
-    }
+#vvp-header {
+  margin: 0px;
+}
 
-    .a-container.vvp-body {
-      padding: 0px;
-      max-width: unset !important;
-      min-width: unset !important;
-    }
+.a-container.vvp-body {
+  padding: 0px;
+  max-width: unset !important;
+  min-width: unset !important;
+}
 
-    #vvp-logo-link img {
-      height: 30px;
-    }
+#vvp-logo-link img {
+  height: var(--logo-link-height, 30px);
+}
 
-    #vvp-header ~ .a-section {
-      display: none;
-    }
+#vvp-header ~ .a-section {
+  display: none;
+}
 
-    .vvp-body>*+* {
-      margin-top: 0px !important;
-    }
+.vvp-body > * + * {
+  margin-top: 0px !important;
+}
 
-    .vvp-header-links-container {
-      margin-right: 0.5rem;
-    }
+.vvp-header-links-container {
+  margin-right: 0.5rem;
+}
 
-    #vvp-items-grid {
-      grid-template-columns: repeat(auto-fill,minmax(110px,auto)) !important;
-      margin-bottom: 0px !important;
-    }
+#vvp-items-grid {
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(var(--grid-column-width, 110px), auto)
+  ) !important;
+  margin-bottom: 0px !important;
+}
 
-    #vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
-      width: 110px !important;
-    }
+#vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
+  width: var(--grid-column-width, 110px) !important;
+}
 
-    #vvp-items-grid .vvp-item-tile .vvp-item-tile-content > * {
-      margin: 0 !important;
-    }
+#vvp-items-grid .vvp-item-tile .vvp-item-tile-content > * {
+  margin: 0 !important;
+}
 
-    #vvp-items-grid .vvp-item-tile .vvp-item-tile-content > img {
-      margin-top: 0.5rem !important;
-    }
+#vvp-items-grid .vvp-item-tile .vvp-item-tile-content > img {
+  margin-top: 0.5rem !important;
+}
 
-    .vvp-item-tile, .a-tab-content {
-      border: none !important;
-    }
+.vvp-item-tile,
+.a-tab-content {
+  border: none !important;
+}
 
-    .a-button-primary {
-      border-radius: 0 !important;
-      margin-bottom: 0.5rem !important;
-      background: #303333;
-      border-color: #303333;
-      transition: 0.2s !important;
-    }
-    
-    .a-button-primary:hover {
-      background: #303333;
-      border-color: #303333;
-      opacity: 0.85;
-    }
-    
-    .a-button-primary:focus:hover {
-    background: #303333;
-      border-color: #303333;
-    }
-    
-    .a-button:focus .a-button-inner .a-button-text, .a-button .a-button-text:hover, .a-button-primary:active:not(.a-button-disabled) .a-button-text {
-      color: white;
-    }
-    
-    .a-button-primary:active:not(.a-button-disabled) {
-      background: #303333;
-      border-color: #303333;
-    }
+.a-button-primary {
+  border-radius: 0 !important;
+  margin-bottom: 0.5rem !important;
+  background: #303333;
+  border-color: #303333;
+  transition: 0.2s !important;
+}
 
-    .a-button-primary .a-button-text {
-      color: white;
-    }
-    
-    .a-button-primary:hover .a-button-text, .a-button-primary:focus .a-button-text {
-      color: white;
-    }
+.a-button-primary:hover {
+  background: #303333;
+  border-color: #303333;
+  opacity: 0.85;
+}
 
-    .a-button-base {
-      border-radius: 0 !important;
-      margin-bottom: 0.5rem !important;
-    }
+.a-button-primary:focus:hover {
+  background: #303333;
+  border-color: #303333;
+}
 
-    .a-button-primary .a-button-inner {
-      background-color: transparent;
-    }
+.a-button:focus .a-button-inner .a-button-text,
+.a-button .a-button-text:hover,
+.a-button-primary:active:not(.a-button-disabled) .a-button-text {
+  color: white;
+}
 
-    #vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container {
-      height: 40px !important;
-    }
+.a-button-primary:active:not(.a-button-disabled) {
+  background: #303333;
+  border-color: #303333;
+}
 
-    /*  Button */
-    #vvp-beta-tag {
-      display: none;
-    }
+.a-button-primary .a-button-text {
+  color: white;
+}
 
-    #vvp-search-button, #vvp-search-text-input {
-      border-radius: 0rem !important;
-    }
+.a-button-primary:hover .a-button-text,
+.a-button-primary:focus .a-button-text {
+  color: white;
+}
 
-    #vvp-search-button #vvp-search-button-announce {
-      line-height: 1 !important;
-    }
+.a-button-base {
+  border-radius: 0 !important;
+  margin-bottom: 0.5rem !important;
+}
 
-    #vvp-search-button .a-button-inner {
-      display: flex;
-      align-items: center;
-  }
+.a-button-primary .a-button-inner {
+  background-color: transparent;
+}
+
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container {
+  height: var(--item-title-height, 40px) !important;
+}
+
+/*  Button */
+#vvp-beta-tag {
+  display: none;
+}
+
+#vvp-search-button,
+#vvp-search-text-input {
+  border-radius: 0rem !important;
+}
+
+#vvp-search-button #vvp-search-button-announce {
+  line-height: 1 !important;
+}
+
+#vvp-search-button .a-button-inner {
+  display: flex;
+  align-items: center;
+}

--- a/desktop/small-items.css
+++ b/desktop/small-items.css
@@ -101,7 +101,7 @@
   .vvp-item-tile
   .vvp-item-tile-content
   > .vvp-item-product-title-container {
-  height: var(--item-title-height, 40px) !important;
+  height: var(--item-tile-height, 40px) !important;
 }
 
 /*  Button */

--- a/desktop/variable-defs.css
+++ b/desktop/variable-defs.css
@@ -1,0 +1,54 @@
+/* Amazon's original grid was based on a "item-title-height" of 80px
+Include a block with only this var if you want the simplest way to update the grid proportions
+The default css will calculate other related values
+
+Each of the variables defined or calculated below can be overridden with a corresponding variable using the naming convention of 
+  
+
+:root {
+    --cust-item-title-height: 40px;
+}
+
+Here are the other variable override names
+In mobile & desktop css files:
+    --cust-grid-column-width
+
+In just desktop css files:
+    --cust-logo-link-height
+
+In just mobile css files:
+    --cust-max-product-title
+    --cust-product-title-text-size
+    
+*/
+:root {
+  /*defaults--mostly for dev reference*/
+  --default-item-title-height: 40px;
+  --default-logo-link-height: 30px;
+  --default-grid-column-width: 110px;
+
+  /*users can define custom  overrides by defining
+    --cust-orgin-param-name
+  
+    in another file or block that occurs before this stylesheet
+  
+    otherwise, values are calculated */
+
+  /*item-title-height is the base value for derived items*/
+  --item-title-height: var(
+    --cust-item-title-height,
+    var(--default-item-title-height)
+  );
+
+  --calc-logo-link-height: calc(var(--item-title-height) * 0.75);
+  --logo-link-height: var(
+    --cust-logo-link-height,
+    var(--calc-logo-link-height)
+  );
+
+  --calc-grid-column-width: calc(var(--item-title-height) * 2.75);
+  --grid-column-width: var(
+    --cust-item-grid-column-width,
+    var(--calc-grid-column-width)
+  );
+}

--- a/desktop/variable-defs.css
+++ b/desktop/variable-defs.css
@@ -6,19 +6,19 @@ Each of the variables defined or calculated below can be overridden with a corre
   
 
 :root {
-    --cust-item-tile-height: 40px;
+    --custom-item-tile-height: 40px;
 }
 
 Here are the other variable override names
 In mobile & desktop css files:
-    --cust-grid-column-width
+    --custom-grid-column-width
 
 In just desktop css files:
-    --cust-logo-link-height
+    --custom-logo-link-height
 
 In just mobile css files:
-    --cust-max-product-title
-    --cust-product-title-text-size
+    --custom-max-product-title
+    --custom-product-title-text-size
     
 */
 :root {
@@ -28,7 +28,7 @@ In just mobile css files:
   --default-grid-column-width: 110px;
 
   /*users can define custom  overrides by defining
-    --cust-orgin-param-name
+    --custom-orgin-param-name
   
     in another file or block that occurs before this stylesheet
   
@@ -36,19 +36,19 @@ In just mobile css files:
 
   /*item-title-height is the base value for derived items*/
   --item-tile-height: var(
-    --cust-item-tile-height,
+    --custom-item-tile-height,
     var(--default-item-tile-height)
   );
 
   --calc-logo-link-height: calc(var(--item-tile-height) * 0.75);
   --logo-link-height: var(
-    --cust-logo-link-height,
+    --custom-logo-link-height,
     var(--calc-logo-link-height)
   );
 
   --calc-grid-column-width: calc(var(--item-tile-height) * 2.75);
   --grid-column-width: var(
-    --cust-item-grid-column-width,
+    --custom-item-grid-column-width,
     var(--calc-grid-column-width)
   );
 }

--- a/desktop/variable-defs.css
+++ b/desktop/variable-defs.css
@@ -6,7 +6,7 @@ Each of the variables defined or calculated below can be overridden with a corre
   
 
 :root {
-    --cust-item-title-height: 40px;
+    --cust-item-tile-height: 40px;
 }
 
 Here are the other variable override names
@@ -23,7 +23,7 @@ In just mobile css files:
 */
 :root {
   /*defaults--mostly for dev reference*/
-  --default-item-title-height: 40px;
+  --default-item-tile-height: 40px;
   --default-logo-link-height: 30px;
   --default-grid-column-width: 110px;
 
@@ -35,18 +35,18 @@ In just mobile css files:
     otherwise, values are calculated */
 
   /*item-title-height is the base value for derived items*/
-  --item-title-height: var(
-    --cust-item-title-height,
-    var(--default-item-title-height)
+  --item-tile-height: var(
+    --cust-item-tile-height,
+    var(--default-item-tile-height)
   );
 
-  --calc-logo-link-height: calc(var(--item-title-height) * 0.75);
+  --calc-logo-link-height: calc(var(--item-tile-height) * 0.75);
   --logo-link-height: var(
     --cust-logo-link-height,
     var(--calc-logo-link-height)
   );
 
-  --calc-grid-column-width: calc(var(--item-title-height) * 2.75);
+  --calc-grid-column-width: calc(var(--item-tile-height) * 2.75);
   --grid-column-width: var(
     --cust-item-grid-column-width,
     var(--calc-grid-column-width)

--- a/desktop/variable-defs.css
+++ b/desktop/variable-defs.css
@@ -12,13 +12,14 @@ Each of the variables defined or calculated below can be overridden with a corre
 Here are the other variable override names
 In mobile & desktop css files:
     --custom-grid-column-width
+    --custom-product-title-text-size
+
 
 In just desktop css files:
     --custom-logo-link-height
 
 In just mobile css files:
     --custom-max-product-title
-    --custom-product-title-text-size
     
 */
 :root {
@@ -26,6 +27,7 @@ In just mobile css files:
   --default-item-tile-height: 40px;
   --default-logo-link-height: 30px;
   --default-grid-column-width: 110px;
+  --default-product-title-text-size: 10px;
 
   /*users can define custom  overrides by defining
     --custom-orgin-param-name
@@ -50,5 +52,11 @@ In just mobile css files:
   --grid-column-width: var(
     --custom-item-grid-column-width,
     var(--calc-grid-column-width)
+  );
+
+  --calc-product-title-text-size: calc(var(--item-tile-height) * 0.333);
+  --product-title-text-size: var(
+    --custom-product-title-text-size,
+    var(--calc-product-title-text-size)
   );
 }

--- a/mobile/mobile.css
+++ b/mobile/mobile.css
@@ -24,29 +24,35 @@ body {
   width: 100% !important;
 }
 
-#nav-main, #vvp-logo-link {
+#nav-main,
+#vvp-logo-link {
   display: none;
 }
 
 .a-tabs {
-  margin: 0px !important; 
+  margin: 0px !important;
 }
 
 .a-tabs li a {
-  padding: 1rem !important; 
+  padding: 1rem !important;
 }
 
 .nav-mobile.nav-ftr-batmobile {
   display: none;
 }
 
-.vvp-tab-set-container [data-a-name="vine-items"] .a-box-inner .vvp-tab-content .vvp-items-button-and-search-container {
+.vvp-tab-set-container
+  [data-a-name="vine-items"]
+  .a-box-inner
+  .vvp-tab-content
+  .vvp-items-button-and-search-container {
   margin: 0px !important;
 }
 
-
-
-#a-page > div.a-container.vvp-body > div.a-tab-container.vvp-tab-set-container > ul {
+#a-page
+  > div.a-container.vvp-body
+  > div.a-tab-container.vvp-tab-set-container
+  > ul {
   margin-bottom: 0px !important;
 }
 
@@ -65,33 +71,81 @@ body {
 
 /* emoji list: https://html-css-js.com/html/character-codes/ */
 
-.a-link-normal[href$="1055398"]:before { content: "🏠";}  /* home & kitchen */
-.a-link-normal[href$="7141123011"]:before { content: "👚";} /* Clothing & Shoe Jewelry */
-.a-link-normal[href$="228013"]:before { content: "🔨";} /* Tools & Home Improvement */
-.a-link-normal[href$="165793011"]:before { content: "🎈"; } /* Toys & Games */
-.a-link-normal[href$="172282"]:before { content: "💻"; } /* Electronics */
-.a-link-normal[href$="3760901"]:before { content: "👨‍⚕️"; } /* Health & Household */
-.a-link-normal[href$="3375251"]:before { content: "⚾"; } /* Sports & Outdoors */
-.a-link-normal[href$="2972638011"]:before { content: "🌳"; } /* Patio, Lawn & Garden */
-.a-link-normal[href$="1064954"]:before { content: "📎"; }  /* Office Products */ 
-.a-link-normal[href$="2619533011"]:before { content: "🐈"; } /* Pet Supplies */
-.a-link-normal[href$="2335752011"]:before { content: "📱"; } /* Cell Phones & Accessories */ 
-.a-link-normal[href$="3760911"]:before { content: "💄"; } /* Beauty & Personal care */
-.a-link-normal[href$="15684181"]:before { content: "🚐"; } /* Automotive */
-.a-link-normal[href$="2617941011"]:before { content: "🎨"; } /* Arts, crafts & Sewing */
-.a-link-normal[href$="165796011"]:before { content: "👶"; } /* Baby Products */
-.a-link-normal[href$="16310091"]:before { content: "🔬"; } /* Industrial & Scientific */
-.a-link-normal[href$="11091801"]:before { content: "🎸"; } /* Musical Instruments */
-.a-link-normal[href$="468642"]:before { content: "🎮"; } /* Video Games */
-.a-link-normal[href$="16310101"]:before { content: "🍎"; } /* Grocery * Gourmet food */
-.a-link-normal[href$="11260432011"]:before { content: "🧤"; } /* Handmade Products */
-.a-link-normal[href$="2619525011"]:before { content: "📻"; } /* Appliances */
-.a-link-normal[href$="283155"]:before { content: "📓"; } /* Books */
-.a-link-normal[href$="229534"]:before { content: "💽"; } /* Software */
-.a-link-normal[href$="2625373011"]:before { content: "🎥"; } /* Movioes & TV */
+.a-link-normal[href$="1055398"]:before {
+  content: "🏠";
+} /* home & kitchen */
+.a-link-normal[href$="7141123011"]:before {
+  content: "👚";
+} /* Clothing & Shoe Jewelry */
+.a-link-normal[href$="228013"]:before {
+  content: "🔨";
+} /* Tools & Home Improvement */
+.a-link-normal[href$="165793011"]:before {
+  content: "🎈";
+} /* Toys & Games */
+.a-link-normal[href$="172282"]:before {
+  content: "💻";
+} /* Electronics */
+.a-link-normal[href$="3760901"]:before {
+  content: "👨‍⚕️";
+} /* Health & Household */
+.a-link-normal[href$="3375251"]:before {
+  content: "⚾";
+} /* Sports & Outdoors */
+.a-link-normal[href$="2972638011"]:before {
+  content: "🌳";
+} /* Patio, Lawn & Garden */
+.a-link-normal[href$="1064954"]:before {
+  content: "📎";
+} /* Office Products */
+.a-link-normal[href$="2619533011"]:before {
+  content: "🐈";
+} /* Pet Supplies */
+.a-link-normal[href$="2335752011"]:before {
+  content: "📱";
+} /* Cell Phones & Accessories */
+.a-link-normal[href$="3760911"]:before {
+  content: "💄";
+} /* Beauty & Personal care */
+.a-link-normal[href$="15684181"]:before {
+  content: "🚐";
+} /* Automotive */
+.a-link-normal[href$="2617941011"]:before {
+  content: "🎨";
+} /* Arts, crafts & Sewing */
+.a-link-normal[href$="165796011"]:before {
+  content: "👶";
+} /* Baby Products */
+.a-link-normal[href$="16310091"]:before {
+  content: "🔬";
+} /* Industrial & Scientific */
+.a-link-normal[href$="11091801"]:before {
+  content: "🎸";
+} /* Musical Instruments */
+.a-link-normal[href$="468642"]:before {
+  content: "🎮";
+} /* Video Games */
+.a-link-normal[href$="16310101"]:before {
+  content: "🍎";
+} /* Grocery * Gourmet food */
+.a-link-normal[href$="11260432011"]:before {
+  content: "🧤";
+} /* Handmade Products */
+.a-link-normal[href$="2619525011"]:before {
+  content: "📻";
+} /* Appliances */
+.a-link-normal[href$="283155"]:before {
+  content: "📓";
+} /* Books */
+.a-link-normal[href$="229534"]:before {
+  content: "💽";
+} /* Software */
+.a-link-normal[href$="2625373011"]:before {
+  content: "🎥";
+} /* Movioes & TV */
 
 #vvp-items-button-container {
-    width: 100% !important;
+  width: 100% !important;
 }
 
 #vvp-browse-nodes-container .child-node {
@@ -100,15 +154,17 @@ body {
 
 /* STRIPPED CATEGORIES */
 #vvp-browse-nodes-container .parent-node {
-  background-color: white
+  background-color: white;
 }
 #vvp-browse-nodes-container > div:nth-child(odd) {
   background-color: #f3f3f3 !important;
 }
-#vvp-browse-nodes-container .parent-node, #vvp-browse-nodes-container .child-node  {
+#vvp-browse-nodes-container .parent-node,
+#vvp-browse-nodes-container .child-node {
   display: flex !important;
 }
-#vvp-browse-nodes-container .parent-node a, #vvp-browse-nodes-container .child-node a {
+#vvp-browse-nodes-container .parent-node a,
+#vvp-browse-nodes-container .child-node a {
   flex-grow: 1 !important;
 }
 
@@ -116,29 +172,28 @@ body {
   text-align: right;
 }
 
-#vvp-items-button-container .a-button-toggle.a-button{
-    margin: 0px !important;
-    padding: 0px !important;
-    width: calc(100% / 3) !important;
-    border-radius: 0px;
+#vvp-items-button-container .a-button-toggle.a-button {
+  margin: 0px !important;
+  padding: 0px !important;
+  width: calc(100% / 3) !important;
+  border-radius: 0px;
 }
 
-#vvp-items-button-container .a-button-toggle.a-button a{
-    font-size: 12px !important;
-    height: 54px;
-    display: flex;
-    align-items: center;
-    padding: 0 !important;
-    justify-content: center !important;
+#vvp-items-button-container .a-button-toggle.a-button a {
+  font-size: 12px !important;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  padding: 0 !important;
+  justify-content: center !important;
 }
 
 .vvp-items-container {
-    flex-direction: column !important;
+  flex-direction: column !important;
 }
 
-
 #vvp-items-grid {
-  grid-template-columns: repeat(auto-fill,minmax(100px,auto)) !important;
+  grid-template-columns: repeat(auto-fill, minmax(100px, auto)) !important;
 }
 
 #vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
@@ -153,7 +208,8 @@ body {
   margin-top: 0.5rem !important;
 }
 
-.vvp-item-tile, .a-tab-content {
+.vvp-item-tile,
+.a-tab-content {
   border: none !important;
 }
 
@@ -180,25 +236,28 @@ body {
   opacity: 0.85 !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container {
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container {
   height: 40px !important;
 }
 
 /* Pagination styles */
 .a-pagination {
   display: flex !important;
-  justify-content: center;  
+  justify-content: center;
 }
 
 .a-pagination li:first-child a,
 .a-pagination li:last-child a {
-    color: transparent !important;
+  color: transparent !important;
 }
 
 .a-pagination li:first-child,
-.a-pagination li:last-child{
-    color: transparent !important;
-    position: relative;
+.a-pagination li:last-child {
+  color: transparent !important;
+  position: relative;
 }
 
 .a-pagination li.a-disabled {
@@ -207,20 +266,20 @@ body {
 
 .a-pagination li:first-child a,
 .a-pagination li:last-child a {
-    display: flex;
-    align-content: center;
-    position: relative;
-    justify-content: center;
+  display: flex;
+  align-content: center;
+  position: relative;
+  justify-content: center;
 }
 
 .a-pagination li:first-child a:before,
 .a-pagination li:last-child a:before {
-    position: absolute !important;
-    color: white !important;
-    font-size: 2rem !important;
-    line-height: 4rem;
-    height: 100%;
-    width: 100%;
+  position: absolute !important;
+  color: white !important;
+  font-size: 2rem !important;
+  line-height: 4rem;
+  height: 100%;
+  width: 100%;
 }
 
 .a-pagination li:first-child a:before {
@@ -235,11 +294,11 @@ body {
   width: 40px !important;
   height: 40px !important;
 }
-.a-pagination li a{
-    padding: 0px !important;
-    margin: 0px !important;
-    height: 100%;
-    line-height: 40px !important;
+.a-pagination li a {
+  padding: 0px !important;
+  margin: 0px !important;
+  height: 100%;
+  line-height: 40px !important;
 }
 
 .vvp-details-btn {
@@ -248,7 +307,7 @@ body {
 }
 
 .vvp-details-btn .a-button-text {
-    padding: 0.5px 0.25px !important;
+  padding: 0.5px 0.25px !important;
 }
 
 /* RFY, AFA, AI */
@@ -261,33 +320,32 @@ body {
 #vvp-items-button--recommended a::before,
 #vvp-items-button--all a::before,
 #vvp-items-button--seller a::before {
-    color: black !important;
-    position: absolute;
-    font-size: 20px;
-    font-weight: bold;
+  color: black !important;
+  position: absolute;
+  font-size: 20px;
+  font-weight: bold;
 }
 
 #vvp-items-button--recommended a::before {
-    content: "RFY" !important;
+  content: "RFY" !important;
 }
 
 #vvp-items-button--all a::before {
-    content: "AFA" !important;
+  content: "AFA" !important;
 }
 
 #vvp-items-button--seller a::before {
-    content: "AI" !important;
+  content: "AI" !important;
 }
-
 
 /* PRODUCT MODAL */
 .a-popover.a-popover-modal.a-declarative.a-popover-modal-fixed-height {
-    height: calc(100% - 100px) !important;
-    width: 100% !important;
-    top: 50px !important;
-    right: 0px !important;
-    left: 0px !important;
-    padding: 0px !important;
+  height: calc(100% - 100px) !important;
+  width: 100% !important;
+  top: 50px !important;
+  right: 0px !important;
+  left: 0px !important;
+  padding: 0px !important;
 }
 
 #vvp-product-details-modal--main {
@@ -295,32 +353,32 @@ body {
 }
 
 #vvp-product-details-modal--tax-value {
-    position: absolute !important;
-    top: 20px !important;
-    z-index: 100;
-    left: 18px;
+  position: absolute !important;
+  top: 20px !important;
+  z-index: 100;
+  left: 18px;
 }
 
 #vvp-product-details-img-container {
-   width: unset !important;
-   height: 150px !important;
-   display: flex !important;
-   justify-content: center !important;
-   position: relative !important;
+  width: unset !important;
+  height: 150px !important;
+  display: flex !important;
+  justify-content: center !important;
+  position: relative !important;
 }
 
-#vvp-product-details-img-container img{
-   height: 150px !important;
+#vvp-product-details-img-container img {
+  height: 150px !important;
 }
 
 /* GHOST ICON */
 #vvp-product-details-modal--limited-quantity {
-    position: absolute !important;
-    bottom: -28px !important;
-    z-index: 101 !important;
-    right: 8px !important;
-    color: transparent !important;
-    width: 41.2px !important;
+  position: absolute !important;
+  bottom: -28px !important;
+  z-index: 101 !important;
+  right: 8px !important;
+  color: transparent !important;
+  width: 41.2px !important;
 }
 
 #vvp-product-details-modal--limited-quantity::before {
@@ -335,7 +393,8 @@ body {
   display: none;
 }
 
-#vvp-search-button, #vvp-search-text-input {
+#vvp-search-button,
+#vvp-search-text-input {
   border-radius: 0rem !important;
 }
 
@@ -363,7 +422,7 @@ body {
   content: "Filter Categories";
   padding: 0.5rem;
   line-height: 3rem;
-  color: #FFF;
+  color: #fff;
 }
 
 #vvp-browse-nodes-container:not(:hover) {
@@ -376,10 +435,9 @@ body {
   height: 75px;
 }
 
-
-#vvp-browse-nodes-container, 
+#vvp-browse-nodes-container,
 #vvp-browse-nodes-container .parent-node,
-#vvp-browse-nodes-container .child-node{
+#vvp-browse-nodes-container .child-node {
   width: unset !important;
 }
 
@@ -416,7 +474,7 @@ body {
 }
 
 .vvp-reviews-table td.vvp-reviews-table--image-col img,
-.vvp-orders-table td.vvp-orders-table--image-col img{
+.vvp-orders-table td.vvp-orders-table--image-col img {
   height: 75px;
 }
 
@@ -428,18 +486,25 @@ body {
 }
 
 #vvp-items-grid {
-  grid-template-columns: repeat(auto-fill,minmax(90px,auto)) !important;
+  grid-template-columns: repeat(auto-fill, minmax(90px, auto)) !important;
 }
 
 #vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
   width: 90px !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container {
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container {
   height: 40px !important;
   font-size: 10px !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content>.vvp-item-product-title-container .a-truncate {
+#vvp-items-grid
+  .vvp-item-tile
+  .vvp-item-tile-content
+  > .vvp-item-product-title-container
+  .a-truncate {
   max-height: 40px !important;
 }

--- a/mobile/mobile.css
+++ b/mobile/mobile.css
@@ -12,7 +12,7 @@ Changing the item-title-height variable should allow the rest of the grid to app
   --default-product-title-text-size: 10px;
 
   /*users can define custom  overrides by defining
-  --cust-orgin-param-name
+  --custom-orgin-param-name
 
   in another file or block that occurs before this stylesheet
 
@@ -20,25 +20,25 @@ Changing the item-title-height variable should allow the rest of the grid to app
 
   /*item-title-height is the base value for derived items*/
   --item-tile-height: var(
-    --cust-item-tile-height,
+    --custom-item-tile-height,
     var(--default-item-tile-height)
   );
 
   --calc-grid-column-width: calc(var(--item-tile-height) * 2.75);
   --grid-column-width: var(
-    --cust-item-grid-column-width,
+    --custom-item-grid-column-width,
     var(--calc-grid-column-width)
   );
 
   --calc-max-product-title: calc(var(--item-tile-height) * 1.25);
   --max-product-title: var(
-    --cust-max-product-title,
+    --custom-max-product-title,
     var(--calc-max-product-title)
   );
 
   --calc-product-title-text-size: calc(var(--item-tile-height) * 0.333);
   --product-title-text-size: var(
-    --cust-product-title-text-size,
+    --custom-product-title-text-size,
     var(--calc-product-title-text-size)
   );
 }

--- a/mobile/mobile.css
+++ b/mobile/mobile.css
@@ -6,7 +6,7 @@ Changing the item-title-height variable should allow the rest of the grid to app
 
 :root {
   /*defaults--mostly for dev reference*/
-  --default-item-title-height: 30px;
+  --default-item-tile-height: 30px;
   --default-grid-column: 90px;
   --default-max-product-title: 100px;
   --default-product-title-text-size: 10px;
@@ -19,24 +19,24 @@ Changing the item-title-height variable should allow the rest of the grid to app
   otherwise, values are calculated */
 
   /*item-title-height is the base value for derived items*/
-  --item-title-height: var(
-    --cust-item-title-height,
-    var(--default-item-title-height)
+  --item-tile-height: var(
+    --cust-item-tile-height,
+    var(--default-item-tile-height)
   );
 
-  --calc-grid-column-width: calc(var(--item-title-height) * 2.75);
+  --calc-grid-column-width: calc(var(--item-tile-height) * 2.75);
   --grid-column-width: var(
     --cust-item-grid-column-width,
     var(--calc-grid-column-width)
   );
 
-  --calc-max-product-title: calc(var(--item-title-height) * 1.25);
+  --calc-max-product-title: calc(var(--item-tile-height) * 1.25);
   --max-product-title: var(
     --cust-max-product-title,
     var(--calc-max-product-title)
   );
 
-  --calc-product-title-text-size: calc(var(--item-title-height) * 0.333);
+  --calc-product-title-text-size: calc(var(--item-tile-height) * 0.333);
   --product-title-text-size: var(
     --cust-product-title-text-size,
     var(--calc-product-title-text-size)

--- a/mobile/mobile.css
+++ b/mobile/mobile.css
@@ -196,10 +196,6 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(100px, auto)) !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
-  width: 100px !important;
-}
-
 #vvp-items-grid .vvp-item-tile .vvp-item-tile-content > * {
   margin: 0 !important;
 }
@@ -234,13 +230,6 @@ body {
 
 .a-button-primary:hover {
   opacity: 0.85 !important;
-}
-
-#vvp-items-grid
-  .vvp-item-tile
-  .vvp-item-tile-content
-  > .vvp-item-product-title-container {
-  height: 40px !important;
 }
 
 /* Pagination styles */

--- a/mobile/mobile.css
+++ b/mobile/mobile.css
@@ -1,3 +1,48 @@
+/* Amazon's original grid was based on a tile height of 80px
+
+Thorvariums suggested styling was based on one of 40px
+
+Changing the item-title-height variable should allow the rest of the grid to approximate visual sense.*/
+
+:root {
+  /*defaults--mostly for dev reference*/
+  --default-item-title-height: 30px;
+  --default-grid-column: 90px;
+  --default-max-product-title: 100px;
+  --default-product-title-text-size: 10px;
+
+  /*users can define custom  overrides by defining
+  --cust-orgin-param-name
+
+  in another file or block that occurs before this stylesheet
+
+  otherwise, values are calculated */
+
+  /*item-title-height is the base value for derived items*/
+  --item-title-height: var(
+    --cust-item-title-height,
+    var(--default-item-title-height)
+  );
+
+  --calc-grid-column-width: calc(var(--item-title-height) * 2.75);
+  --grid-column-width: var(
+    --cust-item-grid-column-width,
+    var(--calc-grid-column-width)
+  );
+
+  --calc-max-product-title: calc(var(--item-title-height) * 1.25);
+  --max-product-title: var(
+    --cust-max-product-title,
+    var(--calc-max-product-title)
+  );
+
+  --calc-product-title-text-size: calc(var(--item-title-height) * 0.333);
+  --product-title-text-size: var(
+    --cust-product-title-text-size,
+    var(--calc-product-title-text-size)
+  );
+}
+
 body {
   padding-right: 0px !important;
 }
@@ -190,10 +235,6 @@ body {
 
 .vvp-items-container {
   flex-direction: column !important;
-}
-
-#vvp-items-grid {
-  grid-template-columns: repeat(auto-fill, minmax(100px, auto)) !important;
 }
 
 #vvp-items-grid .vvp-item-tile .vvp-item-tile-content > * {
@@ -475,19 +516,22 @@ body {
 }
 
 #vvp-items-grid {
-  grid-template-columns: repeat(auto-fill, minmax(90px, auto)) !important;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(var(--grid-column-width), auto)
+  ) !important;
 }
 
 #vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
-  width: 90px !important;
+  width: var(--grid-column-width) !important;
 }
 
 #vvp-items-grid
   .vvp-item-tile
   .vvp-item-tile-content
   > .vvp-item-product-title-container {
-  height: 40px !important;
-  font-size: 10px !important;
+  height: var(--max-product-title) !important;
+  font-size: var(--product-title-text-size) !important;
 }
 
 #vvp-items-grid
@@ -495,5 +539,5 @@ body {
   .vvp-item-tile-content
   > .vvp-item-product-title-container
   .a-truncate {
-  max-height: 40px !important;
+  max-height: var(--max-product-title) !important;
 }


### PR DESCRIPTION
With these changes, a user should be able to more easily update the grid layout of products.
Current users should see minor, if any, changes to mobile, and none to their current desktop implementations to styles.


Adds variables to
- desktop/small-items.css
- desktop/more-description-text.css
with
- desktop/variable-defs.css to support calculated values

and
- mobile/mobile.css

Note: mobile.css has defaults/fallbacks defined as variables. For desktop, fallbacks are inline in the style definitions and also in variable-defs.css

There's no requirement to use variable-defs.css. However, using it makes resizing the product grid easier. Several values are calculated from a base value, making proportions more consistent and requiring less troubleshooting. Also, the styling should continue to work for those that include the file, but don't define any customizations.

The easiest way to redefine the proportions is to change ``--cust-item-tile-height``.


For desktop, a user would do the following to make a slightly larger grid:
```
:root{
  --cust-item-tile-height:50px;
}
@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/variable-defs.css);
@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/small-items.css);
/*any additional imports*/
/*any css with additional redefined styles*/
```

For mobile, depending on the platform, browser, extension, etc, too make a similar change, they would use
```
:root{
  --cust-item-tile-height:50px;
}
@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/desktop/variable-defs.css);
@import url(https://raw.githubusercontent.com/Thorvarium/vine-styling/main/mobile.css);
/*any additional imports*/
/*any css with additional redefined styles*/
```