### PR TITLE
Improved compatibility with the extension "Vine Helper Canada" by:

### DIFF
--- a/desktop/item-zoom.css
+++ b/desktop/item-zoom.css
@@ -1,4 +1,4 @@
-#vvp-items-grid .vvp-item-tile:hover img {
+#vvp-items-grid-container .vvp-item-tile:hover img {
     width: var(--zoom-height, 285px) !important;
     position: fixed !important;
     z-index: 1 !important;
@@ -10,11 +10,11 @@
     pointer-events: none;
 }
 
-#vvp-items-grid .vvp-item-tile:hover .vvp-item-product-title-container {
+#vvp-items-grid-container .vvp-item-tile:hover .vvp-item-product-title-container {
   border-top: calc(var(--grid-column-width, 110px) + 0.5rem) solid transparent !important;
   height: calc(var(--item-tile-height, 40px) + calc(var(--grid-column-width, 110px) + 0.5rem)) !important;
 }
 
-#vvp-items-grid .vvp-item-tile:hover img {
+#vvp-items-grid-container .vvp-item-tile:hover img {
   opacity:100%;
 }

--- a/desktop/more-description-text.css
+++ b/desktop/more-description-text.css
@@ -1,4 +1,4 @@
-#vvp-items-grid
+#vvp-items-grid-container
   .vvp-item-tile
   .vvp-item-tile-content
   > .vvp-item-product-title-container {
@@ -6,7 +6,7 @@
   font-size: var(--product-title-text-size, 10px) !important;
 }
 
-#vvp-items-grid
+#vvp-items-grid-container
   .vvp-item-tile
   .vvp-item-tile-content
   > .vvp-item-product-title-container

--- a/desktop/small-items.css
+++ b/desktop/small-items.css
@@ -24,7 +24,7 @@
   margin-right: 0.5rem;
 }
 
-#vvp-items-grid {
+#vvp-items-grid, #tab-unavailable, #tab-hidden, #tab-favourite {
   grid-template-columns: repeat(
     auto-fill,
     minmax(var(--grid-column-width, 110px), auto)
@@ -32,15 +32,15 @@
   margin-bottom: 0px !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content {
+#vvp-items-grid-container .vvp-item-tile .vvp-item-tile-content {
   width: var(--grid-column-width, 110px) !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content > * {
+#vvp-items-grid-container .vvp-item-tile .vvp-item-tile-content > * {
   margin: 0 !important;
 }
 
-#vvp-items-grid .vvp-item-tile .vvp-item-tile-content > img {
+#vvp-items-grid-container .vvp-item-tile .vvp-item-tile-content > img {
   margin-top: 0.5rem !important;
 }
 


### PR DESCRIPTION
- using the parent div (vvp-items-grid-container) instead of vvp-items-grid
- adding 3 extra selectors for tabs in the extension. This allow the style sheet to be applied in all tabs of the extension.

Note: This should not impact regular use of the style sheets in any way if merged into main branch.