### PR TITLE
Making the emojis visible on Firefox

### DIFF
--- a/desktop/categories-with-emojis-FR.css
+++ b/desktop/categories-with-emojis-FR.css
@@ -36,8 +36,3 @@
   width: 207px !important;
 }
 
-div.parent-node > a.a-link-normal:before {
-    margin-left: 5px;
-    letter-spacing: -20px;
-    margin-right: 23px;
-}

--- a/desktop/categories-with-emojis-UK.css
+++ b/desktop/categories-with-emojis-UK.css
@@ -39,9 +39,3 @@
   margin-left: 38px !important;
   width: 207px !important;
 }
-
-div.parent-node > a.a-link-normal:before {
-    margin-left: 5px;
-    letter-spacing: -20px;
-    margin-right: 23px;
-}

--- a/desktop/categories-with-emojis.css
+++ b/desktop/categories-with-emojis.css
@@ -43,9 +43,3 @@
   margin-left: 38px !important;
   width: 207px !important;
 }
-
-div.parent-node > a.a-link-normal:before {
-    margin-left: 5px;
-    letter-spacing: -20px;
-    margin-right: 23px;
-}


### PR DESCRIPTION
When using the emoji category styles, the emojis were only visible in Chrome, but not Firefox.  Simply removing the styles that messed with the margin,padding, and line spacing for the `::before` elements on the category links seems to fix this.

Firefox now shows the Emojis, and Chrome still shows them, although there is now slightly less space between the emoji and the text.

![image](https://github.com/Thorvarium/vine-styling/assets/463685/bc40c2b1-abac-4f23-b4c1-da53246aef4d)

![image](https://github.com/Thorvarium/vine-styling/assets/463685/910fbc86-20bc-4a99-a76f-0c8fe85faf27)
