### PR TITLE
Add iOS search input borders

### DIFF
--- a/mobile/ios-with-bugfix.css
+++ b/mobile/ios-with-bugfix.css
@@ -77,6 +77,7 @@ body {
 }
 
 #vvp-search-text-input {
+  border: 1px solid;
   width: 100% !important;
 }
 


### PR DESCRIPTION
The invisible search box has annoyed for for a little while now, but it's a simple fix

| Before | After |
| ------ | ----- |
| ![IMG_0881](https://github.com/user-attachments/assets/717f8ea1-0949-4095-829e-8e298dae3014) | ![IMG_0882](https://github.com/user-attachments/assets/6de0ee00-136b-4319-934e-ce4fc0e20d43) |